### PR TITLE
(GH-1) Make hugo-calendly-shortcode a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hugo-calendly-shortcode [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-Add a Calendly link directly into your Hugo page in no time with a simple shortcode block!  
+Add a Calendly link directly into your Hugo page in no time with a simple shortcode block!
 Without having to copy & paste then edit plain html.
 
 Simply add a shortcode block to any page like this...
@@ -23,7 +23,8 @@ You will need:
 # Install hugo-calendly-shortcode
 There are two ways to install it:
 1. [As a git submodule](#install-as-git-submodule).
-2. Simply [copy and paste it](#install-via-copy-and-paste)
+2. [As a hugo module](#install-as-hugo-module).
+3. Simply [copy and paste it](#install-via-copy-and-paste)
 
    Downside: You'll need to manually copy the files for future updates.
 
@@ -50,24 +51,63 @@ git submodule update --remote --merge
 ### Uninstall hugo-calendly-shortcode
 1. Remove the shortcodes from any pages,
 2. Remove the theme from your `config.toml` file,
-3. From Hugo's home folder, run these commands to uninstall the submodule: 
+3. From Hugo's home folder, run these commands to uninstall the submodule:
    ```
    git submodule deinit -f themes/hugo-calendly-shortcode
    git rm -f themes/hugo-calendly-shortcode
+   ```
+
+## Install as Hugo module
+1. Navigate to your Hugo page's home folder.
+2. If you have not already initialized your project to handle hugo modules, do so now by running this command (make sure to replace the uri with _your_ repository uri):
+   ```
+   hugo mod init github.com/your_username/your_site_repo
+   ```
+3. Add the hugo-calendly-shortcode module to your site config:
+   ```yaml
+   module:
+      imports:
+      - path: github.com/bespokesy/hugo-calendly-shortcode
+   ```
+4. Ensure the latest version is installed:
+   ```
+   hugo mod get -u github.com/bespokesy/hugo-calendly-shortcode
+   ```
+
+### Update hugo-calendly-shortcode module
+From Hugo's home folder, run this command to update the module only:
+```bash
+hugo mod get -u github.com/bespokesy/hugo-calendly-shortcode
+```
+You can also update all hugo modules at once:
+```bash
+hugo mod get -u
+```
+And you can update all hugo modules recursively:
+```bash
+hugo mod get -u ./...
+```
+
+### Uninstall hugo-calendly-shortcode module
+1. Remove the shortcodes from any page,
+2. Remove the module from your site config,
+3. From Hugo's home folder, run this command to uninstall the module:
+   ```
+   hugo mod tidy
    ```
 
 ## Install via copy and paste
 1. Copy the [calendly.html](layouts/shortcodes/calendly.html) file into `<your_hugo_page_root>/layouts/shortcodes/` folder.
 
 # Using hugo-calendly
-In order to embed it we need a Calendly calendar name, and a bit of shortcode for your hugo page.  
+In order to embed it we need a Calendly calendar name, and a bit of shortcode for your hugo page.
 That's all.
 
 1. Pick a Calendly calendar name. e.g. `janedoe`
    - *(Optional)* If you want to target a specific event type, append it after a `/` symbol. e.g. `janedoe/my-event`
    - If you need help with event types, [follow Calendly's instructions](https://help.calendly.com/hc/en-us/articles/115002939274-Account-setup#2).
-2. Add a shortcode to your page's markdown file and add the calendar/event name as `calendar` parameter. 
-   
+2. Add a shortcode to your page's markdown file and add the calendar/event name as `calendar` parameter.
+
    For example:
    ```
    {{< calendly calendar="janedoe" />}}
@@ -92,12 +132,12 @@ To change the text, simply add a closing shortcode tag and put your desired text
 Now your Calendly link will say "Book a time to talk now!"
 
 ## More documentation
-For more details on how to use the shortcode, and what you can do with it, visit the [documentation](https://docs.hcs.bespokesy.dev/overview/). 
+For more details on how to use the shortcode, and what you can do with it, visit the [documentation](https://docs.hcs.bespokesy.dev/overview/).
 
 The docs will show [examples of shortcode snippets](https://docs.hcs.bespokesy.dev/examples/hugo-calendly-shortcode/) and what it looks like, available shortcode [parameters](https://docs.hcs.bespokesy.dev/parameters/), how to [solve errors or warnings](https://docs.hcs.bespokesy.dev/errors_warnings/), and more.
 
 # Advanced features with Hugo Calendly Shortcode Plus
-I am building a version with more features for Calendly Premium or Pro owners.  
+I am building a version with more features for Calendly Premium or Pro owners.
 Additional features will enable you to:
 - Use advanced customization features available to Calendly Premium users
 - Apply styles to customize the look and feel for Calendly
@@ -117,5 +157,5 @@ If you want the advanced features, you can buy [Hugo Calendly Shortcode Plus on 
 If you run into any problems that can't be fixed by [consulting the docs](https://docs.hcs.bespokesy.dev/errors_warnings/), check if someone else raised the same [issue on GitHub](https://github.com/bespokesy/hugo-calendly-shortcode/issues) and add a comment. If not, please add a new issue so I can address it.
 
 # Get in touch
-Just want to say hi? Ask something else?  
+Just want to say hi? Ask something else?
 Sure thing! You will find my contact details on [bespokesy.dev/contact](https://bespokesy.dev/contact/).

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bespokesy/hugo-calendly-shortcode
+
+go 1.17


### PR DESCRIPTION
Prior to this PR, the shortcode was only installable via either git submodule or copy-paste methods; this PR turns the theme into a hugo module so that it can be installed/updated/removed more idiomatically.

This PR also adds documentation for installation, update, and removal of the hugo-calendly-shortcode via hugo modules.

Resolves #1.